### PR TITLE
Plotly additions

### DIFF
--- a/plot/plotter-1d.py
+++ b/plot/plotter-1d.py
@@ -15,6 +15,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
+import json
 
 
 def Plot(data, xname, outdir, fs=20):
@@ -37,6 +38,27 @@ def Plot(data, xname, outdir, fs=20):
         fig.savefig(os.path.join(outdir, "{0}_vs_{1}-{2}.svg".format(name.replace('/', '|'), xname.replace('/', '|'), data['_StepNumber'][0])), bbox_inches="tight")
         plt.close(fig)
 
+def Plotly(data, xname, outdir):
+
+    for name in data.keys():
+        if name in ['_StepPhysical', '_StepNumber', xname, 'minmax']:
+            continue
+
+        result = {
+            'data': [{'mode': 'line', 'type': 'scatter', 'x': data[xname].tolist(), 'y': data[name].tolist()}],
+            'layout': {
+                'title': '{1},  time = {0:.1e}'.format(data['_StepPhysical'][0], name),
+                'autosize': 'true', 'hovermode': 'closest',
+                'xaxis': {'type': 'linear', 'range': 'auto', 'title': str(xname), 'autorange': 'false'},
+                'yaxis': {'type': 'linear', 'range': 'auto', 'title': str(name), 'autorange': 'false'},
+            }, 'frames': []
+        }
+
+        output_file = os.path.join(
+            outdir, "{0}_vs_{1}-{2}.json".format(name.replace('/', '|'), xname.replace('/', '|'), data['_StepNumber'][0]))
+
+        with open(output_file, 'w') as f:
+            json.dump(result, f)
 
 def ParseArgs():
     # Args are maybe just better in the dictionary

--- a/plot/plotter-1d.py
+++ b/plot/plotter-1d.py
@@ -82,6 +82,7 @@ def ParseArgs():
     parser.add_argument("-e", "--exclude", help="Don't plot the given y-values", type=str, default=[])
     parser.add_argument("-y", "--y", help="How to generate Y-value(s)", type=str, default="match-dimensions")
     parser.add_argument("-d", "--use-dashboard", help="Using dashboard", type=str, default="off")
+    parser.add_argument("-out", "--output", help="Which output format to provide", type=str, default="plot")
     args = parser.parse_args()
 
     if len(args.only) > 0:
@@ -115,8 +116,12 @@ if __name__ == "__main__":
 
             if plotter.DoPlot:
                 plotter.GetPlotData(y=args.y)
-                Plot(plotter.data, plotter.DimInfo['xname'], plotter.outdir)
+                if args.output and args.output.lower() == 'bp':
+                    StepFile(plotter.data, plotter.outdir)
+                elif args.output and args.output.lower() == 'plotly':
+                    Plotly(plotter.data, plotter.DimInfo['xname'], plotter.outdir)
+                elif not args.output or args.output.lower() == 'matplot':
+                    Plot(plotter.data, plotter.DimInfo['xname'], plotter.outdir)
                 plotter.StepDone()
 
     #@effis-finalize
-

--- a/plot/plotter-1d.py
+++ b/plot/plotter-1d.py
@@ -60,6 +60,20 @@ def Plotly(data, xname, outdir):
         with open(output_file, 'w') as f:
             json.dump(result, f)
 
+def StepFile(data, outdir):
+
+    #output_file = os.path.join(outdir, "{0}".format(data['_StepNumber'][0]))
+
+    with adios2.open(outdir, 'w') as f:
+        for name in data.keys():
+            if name in ['_StepPhysical', '_StepNumber', 'minmax']:
+                continue
+            array = data[name]
+            shape = list(array.shape)
+            count = [array.size]
+            start = [] if shape == [] else [0]
+            f.write(name, array, shape, start, count)
+
 def ParseArgs():
     # Args are maybe just better in the dictionary
     parser = argparse.ArgumentParser()

--- a/util/kittie-compose.py
+++ b/util/kittie-compose.py
@@ -524,6 +524,8 @@ class KittieJob(cheetah.Campaign):
                     self.codesetup[codename][self.keywords['args']] += [self.codesetup[codename]['x']]
                 if "y" in self.codesetup[codename]:
                     self.codesetup[codename][self.keywords['options']]['y'] = self.codesetup[codename]['y']
+		if "output" in self.codesetup[codename]:
+                    self.codesetup[codename][self.keywords['options']]['out'] = self.codesetup[codename]['output']
                 if "data" in self.codesetup[codename]:
                     self.codesetup[codename]['.plotter'] = {'plots': self.codesetup[codename]["data"]}
 


### PR DESCRIPTION
These changes allow an `output` field to be added under `plot-1d` inside the `yaml` file in order to select the desired output. Currently options are `matplot`, `plotly`, or `bp`. Omitting the field defaults to the matplot svg output. Selecting `bp` will create `bp` files for each time step, but will not be uploaded to Girder at this point (this will require further changes to the monitoring code). Selecting `plotly` will generate the required `json` files.