### PR TITLE
cmake installer info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set_property(CACHE PYTHON_PREFIX PROPERTY STRINGS "ON;TRUE;OFF;FALSE")
 
 # Find ADIOS-2
 find_package(ADIOS2 REQUIRED)
-find_package(Yamlcpp REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 #find_package(PythonInterp REQUIRED)
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 set(lib_objects ${CMAKE_CURRENT_SOURCE_DIR}/kittie.cpp)
 add_library(kittie ${lib_objects})
 
-target_link_libraries(kittie PRIVATE adios2::adios2 yaml::cpp)
+target_link_libraries(kittie PRIVATE adios2::adios2 yaml-cpp)
 target_include_directories(kittie 
 	PUBLIC 
 	$<BUILD_INTERFACE:${YAML_INCLUDE_DIRS}>
@@ -54,3 +54,9 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/kittieConfigVersion.cmake
     DESTINATION ${INSTALL_CONFIGDIR}
 )
+
+export(EXPORT kittie-targets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/kittieUtilsTargets.cmake
+    NAMESPACE kittieUtils::)
+
+export(PACKAGE kittie)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -20,6 +20,37 @@ target_include_directories(kittie
 )
 #target_include_directories(kittie PRIVATE $<BUILD_INTERFACE:${YAML_INCLUDE_DIRS}> $<INSTALL_INTERFACE:${YAML_INCLUDE_DIRS}>)
 
-install(TARGETS kittie DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/kittie.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+include(GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/kittie)
 
+install(TARGETS kittie 
+	EXPORT kittie-targets 
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/kittie.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(EXPORT kittie-targets
+    FILE
+        kittieTargets.cmake
+    NAMESPACE
+        kittie::
+    DESTINATION
+        ${INSTALL_CONFIGDIR}
+)
+
+include (CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/kittieConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/kittieConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/kittieConfig.cmake
+    INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/kittieConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/kittieConfigVersion.cmake
+    DESTINATION ${INSTALL_CONFIGDIR}
+)

--- a/src/cpp/kittieConfig.cmake.in
+++ b/src/cpp/kittieConfig.cmake.in
@@ -1,0 +1,14 @@
+get_filename_component(KITTIE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(CMakeFindDependencyMacro)
+
+list(APPEND CMAKE_MODULE_PATH ${KITTIE_CMAKE_DIR})
+
+list(REMOVE_AT CMAKE_MODULE_PATH -1)
+
+find_dependency(boost_regex @MIN_BOOST_VERSION@)
+
+if(NOT TARGET kittie::kittie)
+    include("${kittie_CMAKE_DIR}/kittieTargets.cmake")
+endif()
+
+set(kittie_LIBRARIES kittie::kittie)

--- a/src/cpp/kittieConfig.cmake.in
+++ b/src/cpp/kittieConfig.cmake.in
@@ -5,10 +5,8 @@ list(APPEND CMAKE_MODULE_PATH ${KITTIE_CMAKE_DIR})
 
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 
-find_dependency(boost_regex @MIN_BOOST_VERSION@)
-
 if(NOT TARGET kittie::kittie)
-    include("${kittie_CMAKE_DIR}/kittieTargets.cmake")
+	include("${KITTIE_CMAKE_DIR}/kittieTargets.cmake")
 endif()
 
 set(kittie_LIBRARIES kittie::kittie)


### PR DESCRIPTION
Problem: The kittie cpp library doesn't have a "kittieConfig.cmake." That's problematic if we want to use the kittie library directly rather than use kittie_cpp.py/effis_cpp.py, because the directories would then need to be set by hand.

Solution: I added cmake code to generate the proper target and configs.